### PR TITLE
Update to OpenSMT interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,22 +27,16 @@ addons:
     packages:
       - bison
       - flex
-      - g++-5
       - libgmp-dev
-      - libboost-program-options1.55-dev 
-      - libboost-iostreams1.55-dev
-      - libboost-test1.55-dev
-      - libboost-thread1.55-dev
-      - libboost-system1.55-dev
+      - libboost-program-options-dev
+      - libboost-iostreams-dev
+      - libboost-test-dev
+      - libboost-thread-dev
+      - libboost-system-dev
       - libreadline-dev
       - default-jre
       - gperf
-      - zlib1g-dev
-      - g++-5
 
-before_install:
-  - CC=gcc-5 && CXX=g++-5
-    
 install:
   - bash contrib/install_yices2.sh
   - bash contrib/install_opensmt2.sh

--- a/contrib/install_opensmt2.sh
+++ b/contrib/install_opensmt2.sh
@@ -4,11 +4,12 @@ set -e
 # opensmt2
 pushd .
 # git clone https://scm.ti-edu.ch/repogit/opensmt2.git
-git clone https://github.com/dddejan/opensmt2.git
-cd opensmt2
+#git clone https://github.com/dddejan/opensmt2.git
+git clone -b master --single-branch https://github.com/usi-verification-and-security/opensmt.git
+cd opensmt
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DPRODUCE_PROOF=ON ..
 make 
 sudo make install
-popd 
+popd

--- a/src/smt/opensmt2/opensmt2_internal.cpp
+++ b/src/smt/opensmt2/opensmt2_internal.cpp
@@ -26,9 +26,9 @@ namespace{
 unsigned int sally::smt::opensmt2_internal::instance_id = 0;
 
 sally::smt::opensmt2_internal::opensmt2_internal(sally::expr::term_manager &tm, const sally::options &opts)
-: d_tm{tm}
-, d_instance{instance_id++}
-, term_cache{}
+: d_tm(tm)
+, d_instance(instance_id++)
+, term_cache()
 {
   stacked_A_partitions.emplace_back();
   auto logic_str = opts.get_string("solver-logic");


### PR DESCRIPTION
OpenSMT is now available at GitHub, the link is updated in install_opensmt2.sh.
The compatibility issues with gcc 4.8 have been resolved.
.travis.yml has been cleaned.
