### PR TITLE
Upgrading interface to OpenSMT

### DIFF
--- a/contrib/install_opensmt2.sh
+++ b/contrib/install_opensmt2.sh
@@ -3,13 +3,11 @@ set -e
 
 # opensmt2
 pushd .
-# git clone https://scm.ti-edu.ch/repogit/opensmt2.git
-#git clone https://github.com/dddejan/opensmt2.git
-git clone -b master --single-branch https://github.com/usi-verification-and-security/opensmt.git
+git clone --depth 1 --branch OpenSMT-2.0.0 --single-branch https://github.com/usi-verification-and-security/opensmt.git
 cd opensmt
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DPRODUCE_PROOF=ON ..
+cmake -DCMAKE_BUILD_TYPE=Release -DUSE_READLINE=ON -DPACKAGE_TESTS=OFF ..
 make 
 sudo make install
 popd

--- a/src/smt/CMakeLists.txt
+++ b/src/smt/CMakeLists.txt
@@ -31,7 +31,7 @@ set_source_files_properties(
   opensmt2/opensmt2.cpp opensmt2/opensmt2_internal.cpp opensmt2/opensmt2_term_cache.cpp
   PROPERTIES 
     LANGUAGE CXX
-    COMPILE_FLAGS "-std=c++11 -DPRODUCE_PROOF" 
+    COMPILE_FLAGS "-std=c++11" 
 )
 endif()
 

--- a/src/smt/opensmt2/opensmt2_internal.cpp
+++ b/src/smt/opensmt2/opensmt2_internal.cpp
@@ -35,13 +35,15 @@ sally::smt::opensmt2_internal::opensmt2_internal(sally::expr::term_manager &tm, 
   if (opts.has_option("solver-logic")) {
     auto logic_str = opts.get_string("solver-logic");
     if (logic_str == "QF_LRA") {
-      d_osmt = new Opensmt(qf_lra, "osmt_solver");
+      auto config = std::unique_ptr<SMTConfig>(new SMTConfig());
       const char *msg;
-      bool res = d_osmt->getConfig().setOption(":time-queries", SMTOption{0}, msg);
-      (void) res;
+      bool res = config->setOption(config->o_produce_inter, SMTOption{1}, msg);
       assert(res);
+      (void) res;
       assert(strcmp(msg, "ok") == 0);
-//    osmt->getConfig().sat_theory_propagation = 0;
+      d_osmt = new Opensmt(qf_lra, "osmt_solver", std::move(config));
+      res = d_osmt->getConfig().setOption(":time-queries", SMTOption{0}, msg);
+      assert(res);
 //    res = osmt->getConfig().setOption(":verbosity", SMTOption{2}, msg);
 //    assert(strcmp(msg, "ok") == 0);
 //    res = osmt->getConfig().setOption(":dump-query", SMTOption(1), msg);

--- a/src/smt/opensmt2/opensmt2_internal.cpp
+++ b/src/smt/opensmt2/opensmt2_internal.cpp
@@ -110,7 +110,6 @@ void sally::smt::opensmt2_internal::pop() {
   assert(res);
   assert(d_stacked_A_partitions.size() == d_stack_level + 1); // we start at level 0
   --d_stack_level;
-  assert(d_stack_level == 0); // TODO interpolation with incremental solving may not work properly
   d_stacked_A_partitions.pop_back();
 }
 

--- a/src/smt/y2o2/y2o2.cpp
+++ b/src/smt/y2o2/y2o2.cpp
@@ -58,8 +58,8 @@ y2o2::y2o2(expr::term_manager& tm, const options& opts, utils::statistics& stats
 , d_last_yices2_result(UNKNOWN)
 {
   d_yices2 = factory::mk_solver("yices2", tm, opts, stats);
-//  d_opensmt2 = new delayed_wrapper("opensmt2_delayed", tm, opts, stats, factory::mk_solver("opensmt2", tm, opts, stats));
-  d_opensmt2 = new incremental_wrapper("opensmt2_incremental_wrapper", tm, opts, stats, new opensmt_constructor(tm, opts, stats));
+  d_opensmt2 = new delayed_wrapper("opensmt2_delayed", tm, opts, stats, factory::mk_solver("opensmt2", tm, opts, stats));
+//  d_opensmt2 = new incremental_wrapper("opensmt2_incremental_wrapper", tm, opts, stats, new opensmt_constructor(tm, opts, stats));
   s_instance ++;
 }
 


### PR DESCRIPTION
OpenSMT has a new public release with interface breaking changes related to interpolation.
This PR updates the code in SALLY to use the new interface and updates the OpenSMT installation script to use the released version of OpenSMT. This fixes the version of OpenSMT known to be compatible and prevents unintentional future break of SALLY's builds.

One of the changes in OpenSMT is support for interpolation in incremental mode and in this mode OpenSMT-based interpolation engine in SALLY should be faster. Thus, by default OpenSMT is now  used in incremental mode in SALLY.