### PR TITLE
Fix btor2parser linking and update Yices2 API compatibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,7 @@ if (DREAL_FOUND)
   target_link_libraries(sally ${DREAL_LIBRARIES})
 endif()
 if (BTOR2TOOLS_FOUND)
-  target_link_libraries(sally -lbtor2parser)
+  target_link_libraries(sally ${BTOR2TOOLS_LIBRARIES})
 endif()
 
 target_link_libraries(sally ${Boost_LIBRARIES} ${GMP_LIBRARY})


### PR DESCRIPTION
- Replace hardcoded -lbtor2parser with ${BTOR2TOOLS_LIBRARIES} in CMakeLists.txt to link against the btor2parser library found by cmake
- Update Yices2 API calls from STATUS_* to YICES_STATUS_* constants for compatibility with Yices2 API changes from https://github.com/SRI-CSL/yices2/pull/587